### PR TITLE
Apply themes on startup if settings changed while VSCode was closed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,9 +4,21 @@ import { buildDir, packageJson } from './utils/config'
 import * as inject from './inject'
 import { openSyntaxThemePicker } from './theme/syntax'
 import { saveTheme } from './theme/utils'
+import { createHash } from 'crypto'
 
 // todo: Improve markdown highlighting.
 // const isWeb = vscode.env.appHost != 'desktop'
+
+const getSettingsHash = () => {
+  const config = vscode.workspace.getConfiguration('material-code')
+  const relevant = {
+    colors: config.get('colors'),
+    primaryColor: config.get('primaryColor'),
+    syntaxTheme: config.get('syntaxTheme'),
+    syntaxThemeLight: config.get('syntaxThemeLight')
+  }
+  return createHash('md5').update(JSON.stringify(relevant)).digest('hex')
+}
 
 const updateThemes = async () => {
   await saveTheme(vscode.Uri.joinPath(buildDir, 'dark.json'), true)
@@ -31,6 +43,13 @@ export const activate = async (context: vscode.ExtensionContext) => {
           if (action == 'Open README') vscode.env.openExternal(vscode.Uri.parse(packageJson.repository.url))
         })
     }
+  }
+
+  // Apply themes on startup only if settings changed since last launch
+  const currentHash = getSettingsHash()
+  if (currentHash !== appData.get().settingsHash) {
+    appData.set('settingsHash', currentHash)
+    updateThemes() // no await so it doesn't delay the extension activation
   }
 
   vscode.workspace.onDidChangeConfiguration(event => {


### PR DESCRIPTION
Fixes #21.

`updateThemes()` is only called inside `onDidChangeConfiguration`, which doesn't fire on startup and only runs while VSCode is already open. So if an external tool like Matugen updates `material-code.colors` while VSCode is closed, the new colors are never applied on the next launch even though `settings.json` is correct.

This adds a settings hash check on activation. The hash covers the same four theme-related config keys already checked by `onDidChangeConfiguration` and is persisted via `AppData`. On startup, if the hash differs from the last session, `updateThemes()` runs in the background. The hash is also kept in sync inside `onDidChangeConfiguration` so subsequent cold starts don't redundantly rewrite the theme files.
